### PR TITLE
fix：code wrong.

### DIFF
--- a/solidity-by-example.rst
+++ b/solidity-by-example.rst
@@ -474,10 +474,7 @@
         }
 
         modifier condition(bool _condition) {
-            require(
-                msg.sender == buyer,
-                "Only buyer can call this."
-            );
+            require(_condition);
             _;
         }
 


### PR DESCRIPTION
example ‘Safe Remote Purchase' modifier 'condition' has wrong